### PR TITLE
Add rtw_led_ctrl module parameter. Set so led blinks normally or is a…

### DIFF
--- a/hal/led/hal_usb_led.c
+++ b/hal/led/hal_usb_led.c
@@ -1749,6 +1749,24 @@ void BlinkHandler(PLED_USB pLed)
 		return;
 	}
 
+#ifdef CONFIG_SW_LED
+        /* led_enable 1 is normal blinking so don't cause always on/off */
+	if (padapter->registrypriv.led_ctrl != 1) {
+		if (padapter->registrypriv.led_ctrl == 0)
+		{
+			/* Cause LED to be always off */
+			pLed->BlinkingLedState = RTW_LED_OFF;
+			/* RTW_INFO("Led off\n"); */
+		} else {
+			/* Cause LED to be always on for led_ctrl 2 or greater */
+			pLed->BlinkingLedState = RTW_LED_ON;
+			/* RTW_INFO("Led on\n"); */
+		}
+		/* Skip various switch cases where SwLedBlink*() called below */
+		pLed->CurrLedState = LED_UNKNOWN;
+	}
+#endif
+
 	switch (ledpriv->LedStrategy) {
 	case SW_LED_MODE0:
 		SwLedBlink(pLed);

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -397,6 +397,10 @@ struct registry_priv {
 	u8 trx_share_mode;
 #endif
 	u8 check_hw_status;
+
+#ifdef CONFIG_SW_LED
+	u8 led_ctrl;
+#endif
 };
 
 /* For registry parameters */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -622,6 +622,12 @@ module_param(rtw_mcc_sta_bw40_target_tx_tp, int, 0644);
 module_param(rtw_mcc_sta_bw80_target_tx_tp, int, 0644);
 #endif /*CONFIG_MCC_MODE */
 
+#ifdef CONFIG_SW_LED
+int rtw_led_ctrl = 1;  /* Default to normal blink */
+module_param(rtw_led_ctrl, int, 0644);
+MODULE_PARM_DESC(rtw_led_ctrl,"Led Control: 0=Always off, 1=Normal blink, 2=Always on");
+#endif /* CONFIG_SW_LED */
+
 void rtw_regsty_load_target_tx_power(struct registry_priv *regsty)
 {
 	int path, rs;
@@ -913,6 +919,9 @@ uint loadparam(_adapter *padapter)
 	registry_par->trx_share_mode = rtw_trx_share_mode;
 #endif
 
+#ifdef CONFIG_SW_LED
+	registry_par->led_ctrl = (u8)rtw_led_ctrl;
+#endif /* CONFIG_SW_LED */
 
 	return status;
 }

--- a/rtl8812au.conf
+++ b/rtl8812au.conf
@@ -1,0 +1,17 @@
+# Place this file in directory /etc/modprobe.d/
+# Uncomment one options line so when modprobe occurs either manually or
+# automatically (e.g., after boot with wifi usb adapter connected) it 
+# will set that option value. Manual modprobe will override this file
+# if option value also included at the command line, e.g.,
+# $ sudo modprobe -r rtl8812au
+# $ sudo modprobe rtl8812au rtw_led_ctrl=1
+# 
+# Led always off
+options rtl8812au rtw_led_ctrl=0
+#
+# Default: normal blink of led (all options lines commented causes normal 
+# blink too).
+#options rtl8812au rtw_led_ctrl=1
+#
+# Led always on 
+#options rtl8812au rtw_led_ctrl=2


### PR DESCRIPTION
…lways on or off.

Also adds example /etc/modprobe.d/ configuration file (rtl8812au.conf) that can
be used to set this new parameter option value automatically at boot or when
command "modprobe rtl8812au" is done with no module parameter.

Changes to be committed:
	modified:   hal/led/hal_usb_led.c
	modified:   include/drv_types.h
	modified:   os_dep/linux/os_intfs.c
	new file:   rtl8812au.conf